### PR TITLE
Add properties to pom.xml

### DIFF
--- a/HorseKeep/pom.xml
+++ b/HorseKeep/pom.xml
@@ -3,6 +3,11 @@
   <groupId>HorseKeep</groupId>
   <artifactId>HorseKeep</artifactId>
   <version>0.3.0 BETA</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.5</maven.compiler.target>
+  </properties>
   <repositories>
     <!-- Bukkit can be found at the following repository -->
     <repository>


### PR DESCRIPTION
Without this the `mvn package` command complains. Here is a small sample, there are 15 similar errors.

```
/home/asa/horsekeep/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseTeleportResponse.java:[3,7] enums are not supported in -source 1.3
(use -source 5 or higher to enable enums)
public enum HorseTeleportResponse {

/home/asa/horsekeep/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminList.java:[26,6] generics are not supported in -source 1.3
(use -source 5 or higher to enable generics)
        List<String> horsesList = plugin.manager.getOwnedHorses(playerName);
```
