### PR TITLE
Cleanup

### DIFF
--- a/HorseKeep/pom.xml
+++ b/HorseKeep/pom.xml
@@ -1,47 +1,48 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>HorseKeep</groupId>
-  <artifactId>HorseKeep</artifactId>
-  <version>0.3.1 BETA</version>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
-  </properties>
-  <repositories>
-    <!-- Bukkit can be found at the following repository -->
-    <repository>
-      <id>bukkit-repo</id>
-      <url>http://repo.bukkit.org/content/groups/public/</url>
-    </repository>
-    <repository>
-	  <id>vault-repo</id>
-	  <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
-    </repository>
-  </repositories>
-  <dependencies>
-    <dependency>
-	  <groupId>org.bukkit</groupId>
-	  <artifactId>bukkit</artifactId>
-      <version>1.7.9-R0.1-SNAPSHOT</version>
-	  </dependency>
-  	<dependency>
-	<groupId>net.milkbowl.vault</groupId>
-	<artifactId>Vault</artifactId>
-	<version>1.3.01</version>
-	</dependency>
-	</dependencies>
-	<profiles>
-    <profile>
-        <id>test</id>
-        <activation>
-            <property>
-                <name>test.build.dir</name>
-            </property>
-        </activation>
-        <build>
-            <directory>${test.build.dir}</directory>
-        </build>
-    </profile>
-</profiles>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>HorseKeep</groupId>
+    <artifactId>HorseKeep</artifactId>
+    <version>0.3.1 BETA</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
+    </properties>
+    <repositories>
+        <!-- Bukkit can be found at the following repository -->
+        <repository>
+            <id>bukkit-repo</id>
+            <url>http://repo.bukkit.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>vault-repo</id>
+            <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
+            <version>1.7.9-R0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>net.milkbowl.vault</groupId>
+            <artifactId>Vault</artifactId>
+            <version>1.3.01</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>test</id>
+            <activation>
+                <property>
+                    <name>test.build.dir</name>
+                </property>
+            </activation>
+            <build>
+                <directory>${test.build.dir}</directory>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/HorseKeep/pom.xml
+++ b/HorseKeep/pom.xml
@@ -3,12 +3,24 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>HorseKeep</groupId>
     <artifactId>HorseKeep</artifactId>
-    <version>0.3.1 BETA</version>
+    <version>0.3.2-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.5</maven.compiler.source>
         <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
+    <build>
+        <resources>
+            <resource>
+                <targetPath>.</targetPath>
+                <filtering>true</filtering>
+                <directory>${basedir}/src/main/resources/</directory>
+                <includes>
+                    <include>plugin.yml</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
     <repositories>
         <!-- Bukkit can be found at the following repository -->
         <repository>

--- a/HorseKeep/pom.xml
+++ b/HorseKeep/pom.xml
@@ -15,9 +15,7 @@
                 <targetPath>.</targetPath>
                 <filtering>true</filtering>
                 <directory>${basedir}/src/main/resources/</directory>
-                <includes>
-                    <include>plugin.yml</include>
-                </includes>
+
             </resource>
         </resources>
     </build>

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseData.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseData.java
@@ -1,21 +1,19 @@
 package com.gmail.falistos.HorseKeep;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
-import java.util.Map.Entry;
-import java.util.logging.Level;
-
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.logging.Level;
 
 public class HorseData {
 

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseData.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseData.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.io.File;
 import java.io.IOException;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseKeep.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseKeep.java
@@ -1,56 +1,24 @@
 package com.gmail.falistos.HorseKeep;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-
-import com.gmail.falistos.HorseKeep.commands.CommandAddMember;
-import com.gmail.falistos.HorseKeep.commands.CommandAdminList;
-import com.gmail.falistos.HorseKeep.commands.CommandAdminTransfer;
-import com.gmail.falistos.HorseKeep.commands.CommandDeleteMember;
-import com.gmail.falistos.HorseKeep.commands.CommandGetIdentifier;
-import com.gmail.falistos.HorseKeep.commands.CommandHelp;
-import com.gmail.falistos.HorseKeep.commands.CommandList;
-import com.gmail.falistos.HorseKeep.commands.CommandMembers;
-import com.gmail.falistos.HorseKeep.commands.CommandReload;
-import com.gmail.falistos.HorseKeep.commands.CommandSetIdentifier;
-import com.gmail.falistos.HorseKeep.commands.CommandStore;
-import com.gmail.falistos.HorseKeep.commands.CommandSummon;
-import com.gmail.falistos.HorseKeep.commands.CommandTeleport;
-import com.gmail.falistos.HorseKeep.commands.CommandTeleportAll;
-import com.gmail.falistos.HorseKeep.commands.CommandUnprotect;
+import com.gmail.falistos.HorseKeep.commands.*;
 import net.milkbowl.vault.permission.Permission;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Horse;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.event.entity.EntityTameEvent;
-import org.bukkit.event.entity.PotionSplashEvent;
+import org.bukkit.event.entity.*;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class HorseKeep extends JavaPlugin implements Listener
 {

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseKeep.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseKeep.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -8,21 +8,21 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandAddMember;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandAdminList;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandAdminTransfer;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandDeleteMember;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandGetIdentifier;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandHelp;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandList;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandMembers;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandReload;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandSetIdentifier;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandStore;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandSummon;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandTeleport;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandTeleportAll;
-import main.java.com.gmail.falistos.HorseKeep.commands.CommandUnprotect;
+import com.gmail.falistos.HorseKeep.commands.CommandAddMember;
+import com.gmail.falistos.HorseKeep.commands.CommandAdminList;
+import com.gmail.falistos.HorseKeep.commands.CommandAdminTransfer;
+import com.gmail.falistos.HorseKeep.commands.CommandDeleteMember;
+import com.gmail.falistos.HorseKeep.commands.CommandGetIdentifier;
+import com.gmail.falistos.HorseKeep.commands.CommandHelp;
+import com.gmail.falistos.HorseKeep.commands.CommandList;
+import com.gmail.falistos.HorseKeep.commands.CommandMembers;
+import com.gmail.falistos.HorseKeep.commands.CommandReload;
+import com.gmail.falistos.HorseKeep.commands.CommandSetIdentifier;
+import com.gmail.falistos.HorseKeep.commands.CommandStore;
+import com.gmail.falistos.HorseKeep.commands.CommandSummon;
+import com.gmail.falistos.HorseKeep.commands.CommandTeleport;
+import com.gmail.falistos.HorseKeep.commands.CommandTeleportAll;
+import com.gmail.falistos.HorseKeep.commands.CommandUnprotect;
 import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.Bukkit;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseManager.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseManager.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseManager.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseManager.java
@@ -1,22 +1,14 @@
 package com.gmail.falistos.HorseKeep;
 
+import org.bukkit.*;
+import org.bukkit.configuration.Configuration;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.*;
+import org.bukkit.inventory.ItemStack;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.configuration.Configuration;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Horse;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 /**
  * HorseKeep API

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseTeleportResponse.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/HorseTeleportResponse.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 public enum HorseTeleportResponse {
 

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/Locale.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/Locale.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.io.File;
 import java.io.InputStream;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/Locale.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/Locale.java
@@ -1,11 +1,11 @@
 package com.gmail.falistos.HorseKeep;
 
-import java.io.File;
-import java.io.InputStream;
-
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.InputStream;
 
 public class Locale {
 	

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/MetricsLite.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/MetricsLite.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/MetricsLite.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/MetricsLite.java
@@ -1,12 +1,13 @@
 package com.gmail.falistos.HorseKeep;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.*;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -14,13 +15,6 @@ import java.net.URLEncoder;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.zip.GZIPOutputStream;
-
-import org.bukkit.Bukkit;
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.scheduler.BukkitTask;
 
 public class MetricsLite
 {

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/UUIDUtils.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/UUIDUtils.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep;
+package com.gmail.falistos.HorseKeep;
 
 import java.util.UUID;
 

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/UUIDUtils.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/UUIDUtils.java
@@ -1,9 +1,9 @@
 package com.gmail.falistos.HorseKeep;
 
-import java.util.UUID;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+
+import java.util.UUID;
 
 public class UUIDUtils {
 	

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAddMember.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAddMember.java
@@ -2,7 +2,6 @@ package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
 import com.gmail.falistos.HorseKeep.UUIDUtils;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAddMember.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAddMember.java
@@ -1,7 +1,7 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
-import main.java.com.gmail.falistos.HorseKeep.UUIDUtils;
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.UUIDUtils;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminList.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminList.java
@@ -1,12 +1,11 @@
 package com.gmail.falistos.HorseKeep.commands;
 
-import java.util.List;
-import java.util.UUID;
-
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+
+import java.util.List;
+import java.util.UUID;
 
 public class CommandAdminList extends ConfigurableCommand {
 	public CommandAdminList(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminList.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminList.java
@@ -1,9 +1,9 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import java.util.List;
 import java.util.UUID;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminTransfer.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminTransfer.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminTransfer.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandAdminTransfer.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandDeleteMember.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandDeleteMember.java
@@ -2,7 +2,6 @@ package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
 import com.gmail.falistos.HorseKeep.UUIDUtils;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandDeleteMember.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandDeleteMember.java
@@ -1,7 +1,7 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
-import main.java.com.gmail.falistos.HorseKeep.UUIDUtils;
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.UUIDUtils;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandGetIdentifier.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandGetIdentifier.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Horse;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandGetIdentifier.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandGetIdentifier.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandHelp.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandHelp.java
@@ -1,9 +1,8 @@
 package com.gmail.falistos.HorseKeep.commands;
 
+import com.gmail.falistos.HorseKeep.HorseKeep;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-
-import com.gmail.falistos.HorseKeep.HorseKeep;
 
 public class CommandHelp {
 	public CommandHelp(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandHelp.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandHelp.java
@@ -1,9 +1,9 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 public class CommandHelp {
 	public CommandHelp(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandList.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandList.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,7 +8,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 public class CommandList {
 	public CommandList(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandList.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandList.java
@@ -1,14 +1,12 @@
 package com.gmail.falistos.HorseKeep.commands;
 
-import java.util.List;
-import java.util.UUID;
-
-import org.bukkit.Bukkit;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.gmail.falistos.HorseKeep.HorseKeep;
+import java.util.List;
+import java.util.UUID;
 
 public class CommandList {
 	public CommandList(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandMembers.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandMembers.java
@@ -1,14 +1,13 @@
 package com.gmail.falistos.HorseKeep.commands;
 
-import java.util.List;
-import java.util.UUID;
-
 import com.gmail.falistos.HorseKeep.HorseKeep;
 import com.gmail.falistos.HorseKeep.UUIDUtils;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.UUID;
 
 public class CommandMembers extends ConfigurableCommand {
 	public CommandMembers(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandMembers.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandMembers.java
@@ -1,10 +1,10 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import java.util.List;
 import java.util.UUID;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
-import main.java.com.gmail.falistos.HorseKeep.UUIDUtils;
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.UUIDUtils;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandReload.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandReload.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandReload.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandReload.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSetIdentifier.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSetIdentifier.java
@@ -1,10 +1,9 @@
 package com.gmail.falistos.HorseKeep.commands;
 
+import com.gmail.falistos.HorseKeep.HorseKeep;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import com.gmail.falistos.HorseKeep.HorseKeep;
 
 public class CommandSetIdentifier extends ConfigurableCommand {
 	public CommandSetIdentifier(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSetIdentifier.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSetIdentifier.java
@@ -1,10 +1,10 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 public class CommandSetIdentifier extends ConfigurableCommand {
 	public CommandSetIdentifier(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandStore.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandStore.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Horse;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandStore.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandStore.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSummon.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSummon.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSummon.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandSummon.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleport.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleport.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import java.util.UUID;
 
@@ -7,8 +7,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
-import main.java.com.gmail.falistos.HorseKeep.HorseTeleportResponse;
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
 
 public class CommandTeleport extends ConfigurableCommand {
 	public CommandTeleport(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleport.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleport.java
@@ -1,14 +1,12 @@
 package com.gmail.falistos.HorseKeep.commands;
 
-import java.util.UUID;
-
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
 import org.bukkit.ChatColor;
-
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.gmail.falistos.HorseKeep.HorseKeep;
-import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
+import java.util.UUID;
 
 public class CommandTeleport extends ConfigurableCommand {
 	public CommandTeleport(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleportAll.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleportAll.java
@@ -1,14 +1,13 @@
 package com.gmail.falistos.HorseKeep.commands;
 
-import java.util.List;
-import java.util.UUID;
-
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import com.gmail.falistos.HorseKeep.HorseKeep;
-import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
+import java.util.List;
+import java.util.UUID;
 
 public class CommandTeleportAll extends ConfigurableCommand {
 	public CommandTeleportAll(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleportAll.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandTeleportAll.java
@@ -1,4 +1,4 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
 import java.util.List;
 import java.util.UUID;
@@ -7,8 +7,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
-import main.java.com.gmail.falistos.HorseKeep.HorseTeleportResponse;
+import com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseTeleportResponse;
 
 public class CommandTeleportAll extends ConfigurableCommand {
 	public CommandTeleportAll(HorseKeep plugin, CommandSender sender, String[] args)

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandUnprotect.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandUnprotect.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandUnprotect.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/CommandUnprotect.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/ConfigurableCommand.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/ConfigurableCommand.java
@@ -1,6 +1,6 @@
-package main.java.com.gmail.falistos.HorseKeep.commands;
+package com.gmail.falistos.HorseKeep.commands;
 
-import main.java.com.gmail.falistos.HorseKeep.HorseKeep;
+import com.gmail.falistos.HorseKeep.HorseKeep;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/ConfigurableCommand.java
+++ b/HorseKeep/src/main/java/com/gmail/falistos/HorseKeep/commands/ConfigurableCommand.java
@@ -1,7 +1,6 @@
 package com.gmail.falistos.HorseKeep.commands;
 
 import com.gmail.falistos.HorseKeep.HorseKeep;
-
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 

--- a/HorseKeep/src/main/resources/plugin.yml
+++ b/HorseKeep/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HorseKeep
-main: main.java.com.gmail.falistos.HorseKeep.HorseKeep
+main: com.gmail.falistos.HorseKeep.HorseKeep
 version: ${project.version}
 depends: [Vault]
 commands:

--- a/HorseKeep/src/main/resources/plugin.yml
+++ b/HorseKeep/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HorseKeep
 main: main.java.com.gmail.falistos.HorseKeep.HorseKeep
-version: 0.3.1
+version: ${project.version}
 depends: [Vault]
 commands:
     horse:


### PR DESCRIPTION
This started as just making sure the version number only has to be maintained in `pom.xml`, but I found a couple other things I could clean up.
- Added a section to `pom.xml` that will automatically copy the version number into `plugin.yml` on every build.
- Removed unnecessary (and unconventional) `main.java` from the package name
- Optimized the imports with IntelliJ. It removed unused imports and grouped similar imports together.

I'm curious, which IDE do you use that it produced that `main.java` prefix?
